### PR TITLE
[codex] mise à jour doc d'installation en supprimant la notion de branche

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Avant de commencer, assurez-vous d'avoir :
    ```bash
    # Si vous utilisez git :
    cd ~
-   git clone -b V2 https://github.com/dgedgedge/AstraDIY.git AstraDIY
+   git clone https://github.com/dgedgedge/AstraDIY.git AstraDIY
    cd AstraDIY
    
    # Ou téléchargez et décompressez l'archive dans un répertoire


### PR DESCRIPTION
## Summary
- remove the `-b V2` option from the installation `git clone` command in `README.md`
- align the installation documentation with the current repository state now that V2 has been merged

## Why
The installation guide still referenced cloning the `V2` branch. That was useful before the merge, but it is now outdated and can confuse users following the main setup instructions.

## Impact
Users can follow the standard clone command without needing to know about a historical branch-specific workflow.

## Validation
- reviewed the diff in `README.md`
- confirmed the change is limited to installation documentation
